### PR TITLE
Fix env var checks for VectorService

### DIFF
--- a/packages/vector/src/services/chroma-service.ts
+++ b/packages/vector/src/services/chroma-service.ts
@@ -5,12 +5,22 @@ export class VectorService {
   private embedder: OpenAIEmbeddingFunction
 
   constructor() {
+    const chromaUrl = process.env.CHROMA_URL
+    if (!chromaUrl) {
+      throw new Error("CHROMA_URL environment variable is not defined")
+    }
+
+    const openAiKey = process.env.OPENAI_API_KEY
+    if (!openAiKey) {
+      throw new Error("OPENAI_API_KEY environment variable is not defined")
+    }
+
     this.client = new ChromaClient({
-      path: process.env.CHROMA_URL || "http://localhost:8000"
+      path: chromaUrl
     })
-    
+
     this.embedder = new OpenAIEmbeddingFunction({
-      openai_api_key: process.env.OPENAI_API_KEY || ""
+      openai_api_key: openAiKey
     })
   }
 


### PR DESCRIPTION
## Summary
- validate environment variables in Chroma service

## Testing
- `bun run lint:fix`
- `bun run build` *(fails: Script not found "build" in packages/baml)*

------
https://chatgpt.com/codex/tasks/task_e_68448079b94083258ccb45217988bb39