### PR TITLE
Add MIT license and reference in package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 AngstromSCD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "apps/*",
     "packages/*"
   ],
+  "license": "MIT",
   "scripts": {
     "dev": "bun run dev:services",
     "dev:services": "concurrently -n \"infra,api,baml,vector,frontend\" -c \"blue,green,yellow,magenta,cyan\" \"bun run dev:infra\" \"bun run dev:api\" \"bun run dev:baml\" \"bun run dev:vector\" \"bun run dev:frontend\"",


### PR DESCRIPTION
## Summary
- include MIT license text in root LICENSE file
- specify MIT license in package.json

## Testing
- `bun run lint:fix` *(fails: some errors emitted)*
- `bun run build` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844807c5d888325a0c32f845d3b98b1